### PR TITLE
Modified the Makefiles to account for an externally used ParMETIS orf…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,12 +42,22 @@ LDFLAGS+= -L$(SCHISM_BUILD_DIR)/lib -L. -lpthread -lm -llapack -lblas -Wl,--allo
 endif
 endif
 
-ifneq ($(wildcard $(SCHISM_BUILD_DIR)/lib/libparmetis.a),)
-LIBS+= -lparmetis
-endif
-
-ifneq ($(wildcard $(SCHISM_BUILD_DIR)/lib/libmetis.a),)
-LIBS+= -lmetis
+# P. Velissariou (01/29/2023)
+# Are both metis/parmetis libraries needed in this stage of compilation?
+# If yes, then both parmetis and metis are needed; the "if" statements
+# should account for this fact (e.g., if metis is missing the compilation will fail)
+# What about using externally compiled ParMETIS library? We need to account for this
+# as well (as it is done in the SCHISM code). In the NEMS/src/incmake/component_SCHISM.mk
+# we define the new variable SCHISM_NO_PARMETIS that corresponds to NO_PARMETIS variable
+#in the SCHISM source code and we are checking for the use of the ParMETIS (internal/external)
+# as follows:
+NO_PARMETIS := $(shell echo ${SCHISM_NO_PARMETIS} | tr '[:lower:]' '[:upper:]')
+ifeq ($(NO_PARMETIS),OFF)
+  METIS_LDFLAGS =
+  ifneq ($(PARMETISHOME),)
+    METIS_LDFLAGS := -L$(PARMETISHOME)/lib
+  endif
+  LIBS+= $(METIS_LDFLAGS) -lparmetis -lmetis
 endif
 
 EXPAND_TARGETS= expand_schismlibs

--- a/src/Makefile
+++ b/src/Makefile
@@ -31,7 +31,15 @@ SCHISM_ESMF_OBJS:=$(addprefix ../schism/,$(SCHISM_ESMF))
 
 # @todo parmetis should have been included in lschism_esmf, but
 # that does not seem to work cross-platform ...
-LIBS+= -lhydro -lcore -lparmetis -lmetis
+NO_PARMETIS := $(shell echo ${SCHISM_NO_PARMETIS} | tr '[:lower:]' '[:upper:]')
+ifeq ($(NO_PARMETIS),OFF)
+  METIS_LDFLAGS =
+  ifneq ($(PARMETISHOME),)
+    METIS_LDFLAGS := -L$(PARMETISHOME)/lib
+  endif
+endif
+
+LIBS+= -lhydro -lcore $(METIS_LDFLAGS) -lparmetis -lmetis
 ifdef SCHISM_BUILD_DIR
 F90FLAGS+= -I$(SCHISM_BUILD_DIR)/include -I./model -I./schism -I./driver -I./mossco
 LDFLAGS+= -L$(SCHISM_BUILD_DIR)/lib

--- a/src/PDAF_bindings/Makefile
+++ b/src/PDAF_bindings/Makefile
@@ -9,7 +9,15 @@ include ../include/Rules.mk
 
 # @todo parmetis should have been included in lschism_esmf, but
 # that does not seem to work cross-platform ...
-LIBS+= -lhydro -lcore -lparmetis -lmetis
+NO_PARMETIS := $(shell echo ${SCHISM_NO_PARMETIS} | tr '[:lower:]' '[:upper:]')
+ifeq ($(NO_PARMETIS),OFF)
+  METIS_LDFLAGS =
+  ifneq ($(PARMETISHOME),)
+    METIS_LDFLAGS := -L$(PARMETISHOME)/lib
+  endif
+endif
+
+LIBS+= -lhydro -lcore $(METIS_LDFLAGS) -lparmetis -lmetis
 F90FLAGS+= -I$(SCHISM_BUILD_DIR)/include -I$(PDAF_LIB_DIR)/../include
 
 # Add compiler-specific flags to CFLAGS and F90FLAGS

--- a/src/schism/Makefile
+++ b/src/schism/Makefile
@@ -14,7 +14,15 @@ endif
 
 # @todo parmetis should have been included in lschism_esmf, but
 # that does not seem to work cross-platform ...
-LIBS+= -lhydro -lcore -lparmetis -lmetis
+NO_PARMETIS := $(shell echo ${SCHISM_NO_PARMETIS} | tr '[:lower:]' '[:upper:]')
+ifeq ($(NO_PARMETIS),OFF)
+  METIS_LDFLAGS =
+  ifneq ($(PARMETISHOME),)
+    METIS_LDFLAGS := -L$(PARMETISHOME)/lib
+  endif
+endif
+
+LIBS+= -lhydro -lcore $(METIS_LDFLAGS) -lparmetis -lmetis
 F90FLAGS+= -I $(SCHISM_BUILD_DIR)/include
 ifdef USE_PDAF
 F90FLAGS +=  -I ../PDAF_bindings #-g -traceback -mcmodel=medium #-shared-intel

--- a/src/schism/schism_nuopc_cap.mk.in
+++ b/src/schism/schism_nuopc_cap.mk.in
@@ -26,9 +26,17 @@ ifeq ($(wildcard @@SCHISM_BUILD_DIR@@/lib/libhydro.a),)
 $(error SCHISM has to be compiled before ESMF-SCHISM in build directory @@SCHISM_BUILD_DIR@@.)
 endif
 
+NO_PARMETIS := $(shell echo ${SCHISM_NO_PARMETIS} | tr '[:lower:]' '[:upper:]')
+ifeq ($(NO_PARMETIS),OFF)
+  METIS_LDFLAGS =
+  ifneq ($(PARMETISHOME),)
+    METIS_LDFLAGS := -L$(PARMETISHOME)/lib
+  endif
+endif
+
 #STEMS=schism_bmi schism_esmf_util schism_nuopc_cap
 #OBJS=$(addsuffix .o, $(STEMS))
-LIBS=-lschism_cap -lhydro -lcore -lparmetis -lmetis
+LIBS=-lschism_cap -lhydro -lcore $(METIS_LDFLAGS) -lparmetis -lmetis
 CWD=$(shell pwd)/schism
 
 ifneq ($(wildcard @@SCHISM_BUILD_DIR@@/lib/libfabm_schism.a),)


### PR DESCRIPTION
…or the case that ParMETIS is not used at all; the NEMS/src/incmake/component_SCHISM.mk in CoastalApp defines the new variable SCHISM_NO_PARMETIS=OFF.