### PR TITLE
Restructuring NUOPC cap

### DIFF
--- a/src/schism/schism_esmf_util.F90
+++ b/src/schism/schism_esmf_util.F90
@@ -619,7 +619,7 @@ subroutine SCHISM_StateUpdate1(state, name, farray, kwe, isPtr, rc)
              ! non-ghost elements
              if (ie <= ne) then
                 ip = ip+1
-                farray(ip) = farrayPtr1(ip)
+                farrayPtr1(ip) = farray(ip)
              end if
           end do
        else ! node

--- a/src/schism/schism_nuopc_cap.F90
+++ b/src/schism/schism_nuopc_cap.F90
@@ -336,7 +336,7 @@ subroutine InitializeAdvertise(comp, importState, exportState, clock, rc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
   debug_level = 0
   if (isPresent .and. isSet) then
-     read(cvalue,fmt="(I)") debug_level
+     read(cvalue,*) debug_level
   end if
   write(message, '(A,I1)') trim(compName)//' debug_level is set to ', debug_level
   call ESMF_LogWrite(trim(message), ESMF_LOGMSG_INFO)
@@ -944,7 +944,7 @@ subroutine SCHISM_Export(comp, exportState, clock, rc)
   idry_r8(:) = dble(idry_e(:))
 
   call SCHISM_StateUpdate(exportState, 'ocean_mask', idry_r8, &
-    isPtr=isDataPtr, rc=localrc)
+    isPtr=isDataPtr, onElement=.true., rc=localrc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
 
   !> Write fields on export state for debugging


### PR DESCRIPTION
### PR Description
This PR aims to restructure the existing NUOPC cap. Following items are implemented,

- The import and export state related code is moved to their own routines: `SCHISM_Export` and `SCHISM_Import`. This allow to call them from multiple places such as from`DataInitialize`.
- The `DataInitialize` routine is implemented by specializing `model_label_DataInitialize`. This aims to solve the issue with ocean mask. The export state will be available before running the model. So, the initial condition can be transferred to other components through the specializing `model_label_DataInitialize`.
- The `StateUpdate1` routine is improved to handle element based variables.

### Git Issues Fixed By This PR
- Closes https://github.com/oceanmodeling/schism-esmf/issues/2