### PR TITLE
Bring work related with CICE coupling and node <-> element conversion

### DIFF
--- a/src/schism/schism_esmf_util.F90
+++ b/src/schism/schism_esmf_util.F90
@@ -635,7 +635,6 @@ subroutine SCHISM_StateUpdateF1(state, name, farray, kwe, isPtr, onElement, rc)
        call ESMF_FieldGet(fieldNode, farrayPtr=farrayPtr2, rc=localrc)
        _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc_)
        ! fill internal data structure
-       print*, lbound(farrayPtr2), ubound(farrayPtr2), isPtr%numOwnedNodes
        do ip = 1, isPtr%numOwnedNodes
           farray(isPtr%ownedNodeIds(ip)) = farrayPtr2(ip)
        end do
@@ -1993,8 +1992,6 @@ subroutine SCHISM_MeshCreateNode(comp, kwe, rc)
   fieldNode = ESMF_FieldCreate(name='fieldNode', mesh=meshNode, array=array, &
      meshloc=ESMF_MESHLOC_NODE, rc=localrc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc_)
-  print*, "foreignNodeIds min, max = ", minval(isDataPtr%foreignNodeGlobIds), maxval(isDataPtr%foreignNodeGlobIds)
-  print*, "nodeids min, max = ", minval(nodeids(np+1:npa)), maxval(nodeids(np+1:npa))
 
   ! create routehandle for halo update
   isPresent = ESMF_RouteHandleIsCreated(isDataPtr%haloHandle, rc=localrc)

--- a/src/schism/schism_esmf_util.F90
+++ b/src/schism/schism_esmf_util.F90
@@ -214,7 +214,7 @@ subroutine SCHISM_InitializePtrMap(comp, kwe, rc)
   isPtr%wrap%ptrMap(13)%farrayPtr3 => tr_nd
 
   isPtr%wrap%ptrMap(14)%name = 'ocean_mask'
-  isPtr%wrap%ptrMap(14)%iarrayPtr1 = idry_e
+  isPtr%wrap%ptrMap(14)%iarrayPtr1 => idry_e
   
 end subroutine SCHISM_InitializePtrMap
 

--- a/src/schism/schism_esmf_util.F90
+++ b/src/schism/schism_esmf_util.F90
@@ -61,6 +61,7 @@ module schism_esmf_util
     integer(ESMF_KIND_I4)          :: numOwnedNodes=0
     integer(ESMF_KIND_I4), pointer :: ownedNodeIds(:) => null()
     integer(ESMF_KIND_I4), pointer :: foreignNodeIds(:) => null()
+    integer(ESMF_KIND_I4), pointer :: foreignNodeGlobIds(:) => null()
     type(ESMF_RouteHandle)         :: haloHandle
     type(type_PtrMap), allocatable :: ptrMap(:)
   end type
@@ -74,9 +75,15 @@ module schism_esmf_util
   end type
 
   type(ESMF_MeshLoc) :: meshloc
+  type(ESMF_Mesh) :: meshNode, meshElem
+  type(ESMF_Field) :: fieldNode, fieldElem
+  type(ESMF_RouteHandle) :: routeHandleN2E, routeHandleE2N
   integer :: debug_level
 
-  public meshloc, debug_level 
+  public meshloc, debug_level
+  public meshNode, meshElem
+  public fieldNode, fieldElem
+  public routeHandleN2E, routeHandleE2N
   public clockCreateFrmParam, SCHISM_FieldRealize
   public type_InternalState, type_InternalStateWrapper
   public SCHISM_StateFieldCreateRealize,SCHISM_StateFieldCreate
@@ -554,7 +561,7 @@ end subroutine SCHISM_FieldPtrUpdate
 #define ESMF_METHOD "SCHISM_StateUpdateF1"
 subroutine SCHISM_StateUpdateF1(state, name, farray, kwe, isPtr, onElement, rc)
 
-  use schism_glbl, only: ne, neg, nea
+  use schism_glbl, only: ne, neg, nea, np
   use schism_glbl, only: i34, elnode
 
   type(ESMF_State), intent(inout)                   :: state
@@ -567,6 +574,7 @@ subroutine SCHISM_StateUpdateF1(state, name, farray, kwe, isPtr, onElement, rc)
 
   type(ESMF_Field)               :: field
   real(ESMF_KIND_R8), pointer    :: farrayPtr1(:) => null()
+  real(ESMF_KIND_R8), pointer    :: farrayPtr2(:) => null()
   integer(ESMF_KIND_I4)          :: rc_, localrc
   integer(ESMF_KIND_I4)          :: ie, ip, ii
   integer, dimension(1:4)        :: elLocalNode
@@ -614,18 +622,30 @@ subroutine SCHISM_StateUpdateF1(state, name, farray, kwe, isPtr, onElement, rc)
           farray(isPtr%ownedNodeIds(ip)) = farrayPtr1(ip)
        end do
     else
-       ! nodes that construct the element will get same value
-       ip = 0
-       do ie = 1, nea
-          do ii = 1, i34(ie)
-             elLocalNode(ii) = elnode(ii,ie)
-          end do
-          ! non-ghost elements
-          if (ie <= ne) then
-             ip = ip+1
-             farray(elLocalNode(1:i34(ie))) = farrayPtr1(ip)
-          end if
+       ! transfer element -> node
+       ! perform interpolation from element to node
+       call ESMF_FieldRegrid(field, fieldNode, routehandle=routeHandleE2N, &
+          termorderflag=ESMF_TERMORDER_SRCSEQ, &
+          zeroregion=ESMF_REGION_TOTAL, rc=localrc)
+       _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc_)
+       ! perform halo update
+       call ESMF_FieldHalo(fieldNode, routehandle=isPtr%haloHandle, rc=localrc)
+       _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc_)
+       ! get field on node
+       call ESMF_FieldGet(fieldNode, farrayPtr=farrayPtr2, rc=localrc)
+       _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc_)
+       ! fill internal data structure
+       print*, lbound(farrayPtr2), ubound(farrayPtr2), isPtr%numOwnedNodes
+       do ip = 1, isPtr%numOwnedNodes
+          farray(isPtr%ownedNodeIds(ip)) = farrayPtr2(ip)
        end do
+       ! write field on node and element for debugging
+       if (debug_level > 5) then
+          call ESMF_FieldWriteVTK(fieldNode, trim(name)//'_on_node', rc=localrc)
+          _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc_)
+          call ESMF_FieldWriteVTK(field, trim(name)//'_on_element', rc=localrc)
+         _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc_)
+       end if
     end if
 
     write(message,'(A)') '--- SCHISM_StateUpdateF1 imported '//trim(name)
@@ -641,7 +661,7 @@ subroutine SCHISM_StateUpdateF1(state, name, farray, kwe, isPtr, onElement, rc)
           farrayPtr1(ip) = farray(isPtr%ownedNodeIds(ip))
        end do
     else
-       ! check if input is on element or node
+       ! check if input is on element or node, ocean_mask is on element
        if (eFlag) then ! element
           ! one-to-one map
           ip = 0
@@ -653,18 +673,27 @@ subroutine SCHISM_StateUpdateF1(state, name, farray, kwe, isPtr, onElement, rc)
              end if
           end do
        else ! node
-          ! element will get average of the nodes that construct it
-          ip = 0
-          do ie = 1, nea
-             do ii = 1, i34(ie)
-                elLocalNode(ii) = elnode(ii,ie)
-             end do
-             ! non-ghost elements
-             if (ie <= ne) then
-                ip = ip+1
-                farrayPtr1(ip) = sum(farray(elLocalNode(1:i34(ie))))/dble(i34(ie))
-             end if
+          ! transfer node -> element
+          ! get field on node
+          call ESMF_FieldGet(fieldNode, farrayPtr=farrayPtr2, rc=localrc)
+          _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc_)
+          ! fill it with pointer
+          do ip = 1, isPtr%numOwnedNodes
+             farrayPtr2(ip) = farray(isPtr%ownedNodeIds(ip))
           end do
+          ! perform interpolation from node to element
+          call ESMF_FieldRegrid(fieldNode, field, routehandle=routeHandleN2E, &
+             termorderflag=ESMF_TERMORDER_SRCSEQ, &
+             zeroregion=ESMF_REGION_TOTAL, rc=localrc)
+          _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc_)
+          !
+          ! write field on node and element for debugging
+          if (debug_level > 5) then
+             call ESMF_FieldWriteVTK(fieldNode, trim(name)//'_on_node', rc=localrc)
+             _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc_)
+             call ESMF_FieldWriteVTK(field, trim(name)//'_on_element', rc=localrc)
+            _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc_)
+          end if
        end if
     end if
 
@@ -1147,16 +1176,6 @@ subroutine SCHISM_StateFieldCreateRealize(comp, state, name, field, kwe, rc)
     meshloc=meshloc, rc=localrc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc_)
 
-  isPresent = ESMF_RouteHandleIsCreated(isDataPtr%haloHandle, rc=localrc)
-  _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc_)
-
-  if (.not. isPresent) then 
-    call ESMF_FieldHaloStore(field, routehandle=isDataPtr%haloHandle, rc=localrc)
-    _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc_)
-
-    write(message,'(A)') trim(compName)//' created halo route'
-  endif    
-
   write(message,'(A)') trim(compName)//' created field '//trim(name)
   call ESMF_LogWrite(trim(message), ESMF_LOGMSG_INFO)
 
@@ -1253,16 +1272,6 @@ subroutine SCHISM_StateFieldCreate(comp, state, name, field, kwe, rc)
     meshloc=meshloc, rc=localrc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc_)
 
-  isPresent = ESMF_RouteHandleIsCreated(isDataPtr%haloHandle, rc=localrc)
-  _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc_)
-
-  if (.not. isPresent) then 
-    call ESMF_FieldHaloStore(field, routehandle=isDataPtr%haloHandle, rc=localrc)
-    _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc_)
-
-    write(message,'(A)') trim(compName)//' created halo route'
-  endif    
-
   write(message,'(A)') trim(compName)//' created field '//trim(name)
   call ESMF_LogWrite(trim(message), ESMF_LOGMSG_INFO)
 
@@ -1277,15 +1286,6 @@ subroutine SCHISM_StateFieldCreate(comp, state, name, field, kwe, rc)
     call ESMF_LogWrite(trim(message), ESMF_LOGMSG_WARNING)
     return
   endif
-
-  call ESMF_FieldHalo(field, routehandle=isDataPtr%haloHandle, rc=localrc)
-  _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
-
-  write(message,'(A)') trim(compName)//' added halo route to field '//trim(name)
-  call ESMF_LogWrite(trim(message), ESMF_LOGMSG_INFO)
-
-  write(message,'(A)') trim(compName)//' created and added field '//trim(name)
-  call ESMF_LogWrite(trim(message), ESMF_LOGMSG_INFO)
 
   if (present(rc)) rc = rc_
 
@@ -1310,8 +1310,8 @@ subroutine SCHISM_MeshCreateElement(comp, kwe, rc)
   type(ESMF_KeywordEnforcer), intent(in), optional :: kwe
   integer(ESMF_KIND_I4), intent(out), optional     :: rc
 
-  type(ESMF_Mesh)          :: mesh2d
-  type(ESMF_DistGrid)      :: nodeDistgrid, elementDistgrid
+  type(ESMF_array) :: array
+  type(ESMF_DistGrid)      :: nodalDistgrid, elementDistgrid
   type(ESMF_CoordSys_Flag) :: coordsys
   type(ESMF_Field)         :: field
   type(ESMF_State)         :: exportState
@@ -1495,7 +1495,7 @@ subroutine SCHISM_MeshCreateElement(comp, kwe, rc)
   end do !ie=1,ne
 
   ! create node distgrid
-  nodeDistgrid = ESMF_DistgridCreate(nodeids,rc=localrc)
+  nodalDistgrid = ESMF_DistgridCreate(nodeids,rc=localrc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc_)
 
   ! create element distgrid (distribute)
@@ -1503,12 +1503,12 @@ subroutine SCHISM_MeshCreateElement(comp, kwe, rc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc_)
 
   ! create mesh
-  mesh2d = ESMF_MeshCreate(parametricDim=2, spatialDim=2, &
+  meshElem = ESMF_MeshCreate(parametricDim=2, spatialDim=2, &
     nodeIds=nodeids, &
     nodeCoords=nodecoords2d, &
     nodeOwners=nodeOwners, &
     nodeMask=nodemask, &
-    nodalDistgrid=nodeDistgrid, &
+    nodalDistgrid=nodalDistgrid, &
     elementIds=elementids, &
     elementTypes=elementtypes, &
     elementConn=nv, &
@@ -1520,152 +1520,27 @@ subroutine SCHISM_MeshCreateElement(comp, kwe, rc)
     rc=localrc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc_)
 
+  if (meshloc == ESMF_MESHLOC_ELEMENT) then
+     call ESMF_GridCompSet(comp, mesh=meshElem, rc=localrc)
+     _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc_)
+
+     write(message, '(A)') trim(compName)//' added mesh (element) to component'
+     call ESMF_LogWrite(trim(message), ESMF_LOGMSG_INFO)
+  end if
+
   ! write mesh in VTK format, just for debugging
-  if (debug_level > 0) then 
-    call ESMF_MeshWrite(mesh2d, filename="schism_mesh", rc=rc)
+  if (debug_level > 0) then
+    call ESMF_MeshWrite(meshElem, filename="schism_mesh_element", rc=rc)
     _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc_)
   end if
 
-  ! set component mesh
-  call ESMF_GridCompSet(comp, mesh=mesh2d, rc=localrc)
+  ! create element based field, will be used for transferring data node <-> element
+  array = ESMF_ArrayCreate(elementDistgrid, typekind=ESMF_TYPEKIND_R8, &
+    name='arrayElem', rc=localrc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc_)
-
-  write(message, '(A)') trim(compName)//' added mesh (element) to component'
-  call ESMF_LogWrite(trim(message), ESMF_LOGMSG_INFO)
-
-  ! As the list of owned and non-owned nodes is not preserved in the ESMF_Mesh
-  ! structure, we need to save this information to an internal state, for later 
-  ! use in Array/Field creation.
-  call ESMF_GridCompGetInternalState(comp, internalState, localrc)
+  fieldElem = ESMF_FieldCreate(name='fieldElem', mesh=meshElem, array=array, &
+    meshloc=ESMF_MESHLOC_ELEMENT, rc=localrc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc_)
-
-  isDataPtr => internalState%wrap
-
-  isDataPtr%numOwnedNodes = 0
-  isDataPtr%numForeignNodes = 0
-  do ip = 1, npa
-    ! non-ghost nodes
-    if (ip <= np) then
-      if (nodeowners(ip) == localPet) then 
-        isDataPtr%numOwnedNodes = isDataPtr%numOwnedNodes + 1
-      else 
-        isDataPtr%numForeignNodes = isDataPtr%numForeignNodes + 1
-      end if
-    end if
-  end do
-
-  allocate(isDataPtr%ownedNodeIds(isDataPtr%numOwnedNodes), stat=localrc)
-  allocate(isDataPtr%foreignNodeIds(isDataPtr%numForeignNodes), stat=localrc)
-
-  ownedCount = 0
-  foreignCount = 0
-  do ip = 1, npa
-    ! non-ghost nodes
-    if (ip <= np) then
-      if (nodeowners(ip) == localPet) then
-        ownedCount=ownedCount + 1
-        isDataPtr%ownedNodeIds(ownedCount) = ip
-      else
-        foreignCount=foreignCount + 1
-        isDataPtr%foreignNodeIds(foreignCount) = ip
-      endif
-    end if
-  enddo
-
-  ! query export state
-  call ESMF_GridCompGet(comp, exportState=exportState, rc=localrc)
-  _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc_)
-
-  ! add metadata
-  ! @todo there seem to be lots of violations of DRY here
-  ! @todo ideally, this routine does not depend on NUOPC but works 
-  ! in non-NUOPC context likewise.
-  fieldName = 'mesh_topology'
-  if (NUOPC_IsConnected(exportstate, fieldName=fieldName)) then  
-     field = ESMF_FieldEmptyCreate(name=trim(fieldName), rc=localrc)
-     _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc_) 
-
-     call ESMF_AttributeSet(field, 'cf_role', 'mesh_topology', rc=localrc)
-     _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc_)
-
-     call ESMF_AttributeSet(field, 'topology_dimension', 2, rc=localrc)
-     _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc_)
-
-     call ESMF_AttributeSet(field, 'node_coordinates', 'mesh_node_lon mesh_node_lat', rc=localrc)
-     _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc_)
-
-     call ESMF_AttributeSet(field, 'face_node_connectivity', 'mesh_element_node_connectivity', rc=localrc)
-     _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc_)
-
-     call ESMF_StateAddReplace(exportState, (/field/), rc=localrc)
-     _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc_)
-  end if
-
-  fieldName = 'mesh_global_node_id'
-  if (NUOPC_IsConnected(exportstate, fieldName=fieldName)) then
-     field = ESMF_FieldCreate(mesh2d, name=trim(fieldName), meshloc=ESMF_MESHLOC_NODE, typeKind=ESMF_TYPEKIND_I4, rc=localrc)
-     _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc_)
-
-     call ESMF_FieldGet(field, farrayPtr=farrayPtrI41, rc=localrc)
-     _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc_)
-
-     farrayPtrI41 = isDataPtr%ownedNodeIds
-
-     call ESMF_StateAddReplace(exportstate, (/field/), rc=localrc)
-     _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc_)
-
-     call ESMF_GridCompGet(comp, name=compName, rc=localrc)
-     _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc_)
-
-     write(message, '(A,A)') trim(compName)//' created export field "', trim(fieldName)//'" on nodes'
-     call ESMF_LogWrite(trim(message), ESMF_LOGMSG_INFO)
-
-     nullify(farrayPtrI41)
-  end if
-
-  fieldName = 'mesh_global_element_id'
-  if (NUOPC_IsConnected(exportstate, fieldName=fieldName)) then  
-     field = ESMF_FieldCreate(mesh2d, name=fieldName,  &
-       meshloc=ESMF_MESHLOC_ELEMENT, typeKind=ESMF_TYPEKIND_I4, rc=localrc)
-
-     call ESMF_FieldGet(field, farrayPtr=farrayPtrI41, rc=localrc)
-     _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc_)
-
-     farrayPtrI41 = elementIds(1:nea)
-
-     call ESMF_StateAddReplace(exportstate, (/field/), rc=localrc)
-     _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc_)
-
-     write(message, '(A,A)') trim(compName)//' created export field "', trim(fieldName)//'" on elements'
-     call ESMF_LogWrite(trim(message), ESMF_LOGMSG_INFO)
-
-     nullify(farrayPtrI41)
-  end if
-
-  fieldName = 'mesh_element_node_connectivity'
-  if (NUOPC_IsConnected(exportstate, fieldName=fieldName)) then
-     field = ESMF_FieldCreate(mesh2d, name=trim(fieldName), &
-       meshloc=ESMF_MESHLOC_ELEMENT, ungriddedLBound=(/1/), ungriddedUBound=(/4/), &
-       typeKind=ESMF_TYPEKIND_I4, rc=localrc)
-     _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc_)
-
-     call ESMF_FieldGet(field, farrayPtr=farrayPtrI42, rc=localrc)
-     _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc_)
-
-     do ie = 1, nea
-       do ii = 1, i34(ie)
-         farrayPtrI42(ie,ii) = iplg(elnode(ii,ie))
-       end do
-     end do
-
-     call ESMF_StateAddReplace(exportstate, (/field/), rc=localrc)
-     _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc_)
-
-     write(message, '(A,A)') trim(compName)//' created export field "', trim(fieldName)//'" on elements'
-     call ESMF_LogWrite(trim(message), ESMF_LOGMSG_INFO)
-
-     nullify(farrayPtrI42)
-  end if
 
   ! clean up
   deallocate(nodeids, stat=localrc)
@@ -1697,8 +1572,8 @@ subroutine SCHISM_MeshCreateNode(comp, kwe, rc)
   type(ESMF_KeywordEnforcer), intent(in), optional :: kwe
   integer(ESMF_KIND_I4), intent(out), optional     :: rc
 
-  type(ESMF_Mesh)          :: mesh2d
-  type(ESMF_DistGrid)      :: nodeDistgrid, elementDistgrid, distgrid
+  type(ESMF_array) :: array
+  type(ESMF_DistGrid)      :: nodalDistgrid
   type(ESMF_CoordSys_Flag) :: coordsys
   integer, dimension(:), allocatable            :: nodeids, elementids, nv
   real(ESMF_KIND_R8), dimension(:), allocatable :: nodecoords2d
@@ -1733,6 +1608,7 @@ subroutine SCHISM_MeshCreateNode(comp, kwe, rc)
   type(type_InternalStateWrapper) :: internalState
   type(type_InternalState), pointer :: isDataPtr => null()
   real(ESMF_KIND_R8) ::  tmpm,tmplon
+  logical :: isPresent
 
 !  write(0,*)'__LINE__ inside addSchismMesh'
 !  call ESMF_Finalize() 
@@ -1878,6 +1754,7 @@ subroutine SCHISM_MeshCreateNode(comp, kwe, rc)
   
   allocate(isDataPtr%ownedNodeIds(isDataPtr%numOwnedNodes), stat=localrc)
   allocate(isDataPtr%foreignNodeIds(isDataPtr%numForeignNodes), stat=localrc)
+  allocate(isDataPtr%foreignNodeGlobIds(isDataPtr%numForeignNodes), stat=localrc)
 
   ownedCount = 0
   foreignCount = 0
@@ -1888,6 +1765,7 @@ subroutine SCHISM_MeshCreateNode(comp, kwe, rc)
     else
       foreignCount=foreignCount + 1
       isDataPtr%foreignNodeIds(foreignCount) = ip
+      isDataPtr%foreignNodeGlobIds(foreignCount) = iplg(ip)
     endif
   enddo
 
@@ -1962,11 +1840,11 @@ subroutine SCHISM_MeshCreateNode(comp, kwe, rc)
 
   !> This is a three-part mesh generation, with later addition of node 
   !> and element information
-  mesh2d = ESMF_MeshCreate(parametricDim=2, spatialdim=2, coordSys=coordsys, rc=localrc)
+  meshNode = ESMF_MeshCreate(parametricDim=2, spatialdim=2, coordSys=coordsys, rc=localrc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc_) 
 
   !> We can pass a nodalDistgrid (optional) 
-  call ESMF_MeshAddNodes(mesh2d, nodeIds=nodeids, nodeCoords=nodecoords2d, &
+  call ESMF_MeshAddNodes(meshNode, nodeIds=nodeids, nodeCoords=nodecoords2d, &
     nodeOwners=nodeowners, nodeMask=nodemask, rc=localrc) 
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc_)
 
@@ -1976,11 +1854,11 @@ subroutine SCHISM_MeshCreateNode(comp, kwe, rc)
   call ESMF_LogWrite(trim(message), ESMF_LOGMSG_INFO)
 
   !> optional arguments are elementArea and elementDistgrid
-  call ESMF_MeshAddElements(mesh2d, elementIds=elementids, elementTypes=elementtypes, &
+  call ESMF_MeshAddElements(meshNode, elementIds=elementids, elementTypes=elementtypes, &
     elementConn=nv, elementMask=elementmask, elementCoords=elementcoords2d, rc=localrc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc_)
 
-  call ESMF_MeshGet(mesh2d, numOwnedNodes=npo, numOwnedElements=neo, &
+  call ESMF_MeshGet(meshNode, numOwnedNodes=npo, numOwnedElements=neo, &
     rc=localrc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc_)
   
@@ -1997,11 +1875,19 @@ subroutine SCHISM_MeshCreateNode(comp, kwe, rc)
     ' augmented and ', ne, ' resident elements ', neo, ' owned elements'
   call ESMF_LogWrite(trim(message), ESMF_LOGMSG_INFO)
 
-  call ESMF_GridCompSet(comp, mesh=mesh2d, rc=localrc)
-  _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc_)
+  if (meshloc == ESMF_MESHLOC_NODE) then
+     call ESMF_GridCompSet(comp, mesh=meshNode, rc=localrc)
+     _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc_)
 
-  write(message, '(A)') trim(compName)//' added mesh (node) to component'
-  call ESMF_LogWrite(trim(message), ESMF_LOGMSG_INFO)
+     write(message, '(A)') trim(compName)//' added mesh (node) to component'
+     call ESMF_LogWrite(trim(message), ESMF_LOGMSG_INFO)
+  end if
+
+  ! write mesh in VTK format, just for debugging
+  if (debug_level > 0) then
+    call ESMF_MeshWrite(meshNode, filename="schism_mesh_node", rc=rc)
+    _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc_)
+  end if
 
   !> @todo the following steps don't work in the NUOPC cap yet
 
@@ -2037,7 +1923,7 @@ subroutine SCHISM_MeshCreateNode(comp, kwe, rc)
   !_SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc_)
 
   fieldName = 'mesh_global_node_id'
-  field = ESMF_FieldCreate(mesh2d, name=fieldName,  &
+  field = ESMF_FieldCreate(meshNode, name=fieldName,  &
     meshloc=ESMF_MESHLOC_NODE, typeKind=ESMF_TYPEKIND_I4, rc=localrc)
 
   call ESMF_FieldGet(field, farrayPtr=farrayPtrI41, rc=localrc)
@@ -2056,7 +1942,7 @@ subroutine SCHISM_MeshCreateNode(comp, kwe, rc)
   call ESMF_LogWrite(trim(message), ESMF_LOGMSG_INFO)
 
   fieldName = 'mesh_global_element_id'
-  field = ESMF_FieldCreate(mesh2d, name=fieldName,  &
+  field = ESMF_FieldCreate(meshNode, name=fieldName,  &
     meshloc=ESMF_MESHLOC_ELEMENT, typeKind=ESMF_TYPEKIND_I4, rc=localrc)
 
   call ESMF_FieldGet(field, farrayPtr=farrayPtrI41, rc=localrc)
@@ -2074,7 +1960,7 @@ subroutine SCHISM_MeshCreateNode(comp, kwe, rc)
   nullify(farrayPtrI41)
 
   fieldName = 'mesh_element_node_connectivity'
-  field = ESMF_FieldCreate(mesh2d, name=fieldName, &
+  field = ESMF_FieldCreate(meshNode, name=fieldName, &
     meshloc=ESMF_MESHLOC_ELEMENT, ungriddedLBound=(/1/), ungriddedUBound=(/4/), &
     typeKind=ESMF_TYPEKIND_I4, rc=localrc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc_)
@@ -2096,6 +1982,30 @@ subroutine SCHISM_MeshCreateNode(comp, kwe, rc)
   call ESMF_LogWrite(trim(message), ESMF_LOGMSG_INFO)
 
   nullify(farrayPtrI42)
+
+  ! create node based field, will be used for transferring data node <-> element
+  ! it does not have ghost nodes only resident ones
+  call ESMF_MeshGet(meshNode, nodalDistgrid=nodalDistgrid, rc=localrc)
+  _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc_)
+  array = ESMF_ArrayCreate(nodalDistgrid, typekind=ESMF_TYPEKIND_R8, &
+     haloSeqIndexList=isDataPtr%foreignNodeGlobIds, name='arrayNode', rc=localrc)
+  _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc_)
+  fieldNode = ESMF_FieldCreate(name='fieldNode', mesh=meshNode, array=array, &
+     meshloc=ESMF_MESHLOC_NODE, rc=localrc)
+  _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc_)
+  print*, "foreignNodeIds min, max = ", minval(isDataPtr%foreignNodeGlobIds), maxval(isDataPtr%foreignNodeGlobIds)
+  print*, "nodeids min, max = ", minval(nodeids(np+1:npa)), maxval(nodeids(np+1:npa))
+
+  ! create routehandle for halo update
+  isPresent = ESMF_RouteHandleIsCreated(isDataPtr%haloHandle, rc=localrc)
+  _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc_)
+
+  if (.not. isPresent) then
+     call ESMF_FieldHaloStore(field, routehandle=isDataPtr%haloHandle, rc=localrc)
+     _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc_)
+     write(message,'(A)') trim(compName)//' created halo route'
+     call ESMF_LogWrite(trim(message), ESMF_LOGMSG_INFO)
+  end if
 
   ! clean up
   deallocate(nodeids, stat=localrc)

--- a/src/schism/schism_esmf_util.F90
+++ b/src/schism/schism_esmf_util.F90
@@ -155,7 +155,6 @@ subroutine SCHISM_InitializePtrMap(comp, kwe, rc)
   integer(ESMF_KIND_I4), intent(out), optional        :: rc
 
   integer(ESMF_KIND_I4)           :: rc_, localrc, i, ip 
-  integer(ESMF_KIND_I4), allocatable, target :: idry_ini(:)
   character(len=ESMF_MAXSTR)      :: message, name
   type(type_InternalStateWrapper) :: isPtr
 
@@ -167,12 +166,6 @@ subroutine SCHISM_InitializePtrMap(comp, kwe, rc)
 
   call ESMF_GridCompGetInternalState(comp, isPtr, localrc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
-
-  !Initialize idry_ini
-  if (.not. allocated(idry_ini)) then
-     allocate(idry_ini(size(idry_e)))
-     idry_ini(:) = 0
-  end if
 
   allocate(isPtr%wrap%ptrMap(14))
 
@@ -221,7 +214,7 @@ subroutine SCHISM_InitializePtrMap(comp, kwe, rc)
   isPtr%wrap%ptrMap(13)%farrayPtr3 => tr_nd
 
   isPtr%wrap%ptrMap(14)%name = 'ocean_mask'
-  isPtr%wrap%ptrMap(14)%iarrayPtr1 = idry_ini !Force to all elements (For import sflux vars)
+  isPtr%wrap%ptrMap(14)%iarrayPtr1 = idry_e
   
 end subroutine SCHISM_InitializePtrMap
 

--- a/src/schism/schism_nuopc_cap.F90
+++ b/src/schism/schism_nuopc_cap.F90
@@ -626,11 +626,11 @@ subroutine InitializeRealize(comp, importState, exportState, clock, rc)
   localrc= ESMF_SUCCESS
 
 !<<<<<<< HEAD
- !=======
-   !> @todo move addSchismMesh back to schism_esmf_util to share with ESMF cap
-   !> call addSchismMesh(comp, ownedNodes=ownedNodes, foreignNodes=foreignNodes, rc=localrc)
-   !call addSchismMesh(comp, localrc)
- !>>>>>>> a9a0ce0 (Use MeshCreate instead off add Mesh)
+!=======
+  !> @todo move addSchismMesh back to schism_esmf_util to share with ESMF cap
+  !> call addSchismMesh(comp, ownedNodes=ownedNodes, foreignNodes=foreignNodes, rc=localrc)
+  !call addSchismMesh(comp, localrc)
+!>>>>>>> a9a0ce0 (Use MeshCreate instead off add Mesh)
   if (meshloc == ESMF_MESHLOC_NODE) then
     call SCHISM_MeshCreateNode(comp, rc=localrc)
     _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)

--- a/src/schism/schism_nuopc_cap.F90
+++ b/src/schism/schism_nuopc_cap.F90
@@ -391,7 +391,6 @@ subroutine InitializeAdvertise(comp, importState, exportState, clock, rc)
   call NUOPC_FieldDictionaryAddIfNeeded("mixed_layer_depth", "1", localrc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
 
-
   !================================================================================
   !                      +-------------------------------+
   !                      |  Adding CICE fields to ufs_fd |
@@ -446,7 +445,6 @@ subroutine InitializeAdvertise(comp, importState, exportState, clock, rc)
   call NUOPC_FieldDictionaryAddIfNeeded("Si_CdnIO", "1", localrc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
 
-  
   !================================================================================
   !                               +------------------------+
   !                               | Advertizing CICE states|
@@ -494,7 +492,6 @@ subroutine InitializeAdvertise(comp, importState, exportState, clock, rc)
   !  ice thickness potential  -------------------------\ 
   call NUOPC_Advertise(importState, "Si_hi", rc=localrc)
  
-
   ! for coupling to ATM/DATM
   call NUOPC_Advertise(importState, "air_pressure_at_sea_level", rc=localrc)
   call NUOPC_Advertise(importState, "inst_zonal_wind_height10m", rc=localrc)
@@ -558,7 +555,7 @@ subroutine InitializeAdvertise(comp, importState, exportState, clock, rc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
 
   call NUOPC_FieldAdvertise(exportState, "depth-averaged_y-velocity", "m s-1", localrc)
-  _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc) 
+  _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
 
   call NUOPC_FieldAdvertise(exportState, "sea_surface_height_above_sea_level", "m", localrc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
@@ -628,6 +625,12 @@ subroutine InitializeRealize(comp, importState, exportState, clock, rc)
   rc = ESMF_SUCCESS
   localrc= ESMF_SUCCESS
 
+!<<<<<<< HEAD
+ !=======
+   !> @todo move addSchismMesh back to schism_esmf_util to share with ESMF cap
+   !> call addSchismMesh(comp, ownedNodes=ownedNodes, foreignNodes=foreignNodes, rc=localrc)
+   !call addSchismMesh(comp, localrc)
+ !>>>>>>> a9a0ce0 (Use MeshCreate instead off add Mesh)
   if (meshloc == ESMF_MESHLOC_NODE) then
     call SCHISM_MeshCreateNode(comp, rc=localrc)
     _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
@@ -1150,7 +1153,7 @@ end subroutine SCHISM_RemoveUnconnectedFields
 #define ESMF_METHOD "SCHISM_Export"
 subroutine SCHISM_Export(comp, exportState, clock, rc)
 
-  use schism_glbl,      only: nvrt, eta2, dav, uu2, vv2, tr_nd, idry_e, deta1_dxy_elem, dp, znl, nvrt, npa
+  use schism_glbl,      only: nvrt, eta2, dav, uu2, vv2, tr_nd, idry_e, npa, deta1_dxy_elem, dp, znl, nvrt,
   use schism_esmf_util, only: SCHISM_StateUpdate
 
   implicit none
@@ -1190,7 +1193,7 @@ subroutine SCHISM_Export(comp, exportState, clock, rc)
   call SCHISM_StateUpdate(exportState, 'sea_surface_height_above_sea_level', eta2, &
     isPtr=isDataPtr, rc=localrc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
- 
+
   !> Sea surface graidend (for cice coupling) 
   call SCHISM_StateUpdate(exportState, 'sea_surface_slope_zonal', deta1_dxy_elem(:,1), &
     isPtr=isDataPtr, rc=localrc)
@@ -1295,24 +1298,6 @@ subroutine SCHISM_Import(comp, importState, clock, rc)
   type(ESMF_State)   , intent(inout) :: importState
   type(ESMF_Clock)   , intent(in)    :: clock
   integer            , intent(inout) :: rc
-  !>---------------------------------------------------
-  !         Creating vars to dump cice fields to
-  !>---------------------------------------------------
-  !real(ESMF_KIND_R8), allocatable, save, target :: uvice(:)
-  !real(ESMF_KIND_R8), allocatable, save, target :: vvice(:)
-  !real(ESMF_KIND_R8), allocatable, save, target :: taux(:)
-  !real(ESMF_KIND_R8), allocatable, save, target :: tauy(:)
-  !real(ESMF_KIND_R8), allocatable, save, target :: vsno(:)
-  !real(ESMF_KIND_R8), allocatable, save, target :: vice(:)
-  !real(ESMF_KIND_R8), allocatable, save, target :: aice(:)
-  !real(ESMF_KIND_R8), allocatable, save, target :: ifresh_flux(:)
-  !real(ESMF_KIND_R8), allocatable, save, target :: isalt_flux(:)
-  !real(ESMF_KIND_R8), allocatable, save, target :: iheat_flux(:)  
-  !real(ESMF_KIND_R8), allocatable, save, target :: isw_pen(:)
-  !real(ESMF_KIND_R8), allocatable, save, target :: frzmlt(:)
-
-  !>---------------------------------------------------
-  !>---------------------------------------------------
   
   !> Local variables
   type(ESMF_Time) :: currTime
@@ -1557,6 +1542,7 @@ subroutine SCHISM_Import(comp, importState, clock, rc)
       srad_th_ice(i)  = isw_pen(i)
 
     else
+
       !> No ice so all these values are zero
       tau_oi(1,i)      = real(0)
       tau_oi(2,i)      = real(0)
@@ -1564,11 +1550,9 @@ subroutine SCHISM_Import(comp, importState, clock, rc)
       fresh_wa_flux(i) = real(0) !+ max(real(0.0),frzmlt(i))
       net_heat_flux(i) = real(0)
       srad_th_ice(i)  = real(0)
+    
     endif
-
   enddo
-
-
 
   !> Write fields on import state for debugging
   if (debug_level > 0) then

--- a/src/schism/schism_nuopc_cap.F90
+++ b/src/schism/schism_nuopc_cap.F90
@@ -1153,7 +1153,7 @@ end subroutine SCHISM_RemoveUnconnectedFields
 #define ESMF_METHOD "SCHISM_Export"
 subroutine SCHISM_Export(comp, exportState, clock, rc)
 
-  use schism_glbl,      only: nvrt, eta2, dav, uu2, vv2, tr_nd, idry_e, npa, deta1_dxy_elem, dp, znl, nvrt,
+  use schism_glbl,      only: nvrt, eta2, dav, uu2, vv2, tr_nd, idry_e, npa, deta1_dxy_elem, dp, znl, nvrt
   use schism_esmf_util, only: SCHISM_StateUpdate
 
   implicit none

--- a/src/schism/schism_nuopc_cap.F90
+++ b/src/schism/schism_nuopc_cap.F90
@@ -384,6 +384,117 @@ subroutine InitializeAdvertise(comp, importState, exportState, clock, rc)
   call NUOPC_FieldDictionaryAddIfNeeded("ocean_mask", "1", localrc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
 
+  call NUOPC_FieldDictionaryAddIfNeeded("sea_surface_slope_zonal", "1", localrc)
+  _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
+  call NUOPC_FieldDictionaryAddIfNeeded("sea_surface_slope_merid", "1", localrc)
+  _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
+  call NUOPC_FieldDictionaryAddIfNeeded("mixed_layer_depth", "1", localrc)
+  _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
+
+
+  !================================================================================
+  !                      +-------------------------------+
+  !                      |  Adding CICE fields to ufs_fd |
+  !                      +-------------------------------+
+  !================================================================================
+
+  !  Zonal ice velocity [m/s] --------------------------------------\
+  call NUOPC_FieldDictionaryAddIfNeeded("Si_uvel", "m s-1", localrc)
+  _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
+
+  !  Merid ice velocity [m/s] --------------------------------------\
+  call NUOPC_FieldDictionaryAddIfNeeded("Si_vvel", "m s-1", localrc)
+  _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
+
+  !  Zonal ice-to-ocean stress [N/m/m] -------------------------------\
+  call NUOPC_FieldDictionaryAddIfNeeded("Fioi_taux", "N m-2", localrc)
+  _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
+
+  !  Merid ice-to-ocean stress [N/m/m] -------------------------------\
+  call NUOPC_FieldDictionaryAddIfNeeded("Fioi_tauy", "N m-2", localrc)
+  _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
+
+  !  Snow volume (per unit area) [m] ----------------------------\
+  call NUOPC_FieldDictionaryAddIfNeeded("Si_vsno", "m", localrc)
+  _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
+
+  !  Ice volume (per unit area) [m] ---------- ------------------\
+  call NUOPC_FieldDictionaryAddIfNeeded("Si_vice", "m", localrc)
+  _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
+
+  !  Fresh water flux due to ice melting [kg/m/m/s] ------------------------\
+  call NUOPC_FieldDictionaryAddIfNeeded("Fioi_meltw", "kg m-2 s-1", localrc)
+  _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
+ 
+  !  Salt flux due to ice formation/melt [kg/m/m/s] -----------------------\
+  call NUOPC_FieldDictionaryAddIfNeeded("Fioi_salt", "kg m-2 s-1", localrc)
+  _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
+
+  !  Heat flux at the base of the ice [W/m/m] --------------------------\
+  call NUOPC_FieldDictionaryAddIfNeeded("Fioi_melth", "W m-2", localrc)
+  _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
+
+  !  Shortwave radiation through sea ice coverage [W/m/m] --------------\
+  call NUOPC_FieldDictionaryAddIfNeeded("Fioi_swpen", "W m-2", localrc)
+  _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
+  
+  !  Freezing melting potential (energy for ice formation) [W/m/m] ---\
+  call NUOPC_FieldDictionaryAddIfNeeded("Si_frzmlt", "W m-2", localrc)
+  _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
+
+  !  Ice-to-ocean drage coef [Unitless] -------------------------\
+  call NUOPC_FieldDictionaryAddIfNeeded("Si_CdnIO", "1", localrc)
+  _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
+
+  
+  !================================================================================
+  !                               +------------------------+
+  !                               | Advertizing CICE states|
+  !                               +------------------------+
+  !=================================================================================
+  
+  ! Sea surface height--------------------------------------------------------------\ 
+  call NUOPC_Advertise(importState, "sea_surface_height_above_sea_level", rc=localrc)
+  
+  !  Zonal/Merid ice velocity -----------------------------\
+  call NUOPC_Advertise(importState, "Si_uvel", rc=localrc)
+  call NUOPC_Advertise(importState, "Si_vvel", rc=localrc)
+
+  !  Zonal/Merid ice-to-ocn stress ------------------------\
+  call NUOPC_Advertise(importState, "Fioi_taux", rc=localrc)
+  call NUOPC_Advertise(importState, "Fioi_tauy", rc=localrc)
+ 
+  !  Snow volume ----------------------------------------\
+  call NUOPC_Advertise(importState, "Si_vsno", rc=localrc)
+
+  !  Ice volume -----------------------------------------\
+  call NUOPC_Advertise(importState, "Si_vice", rc=localrc)
+
+  !  Ice fraction ----------------------------------------\
+  call NUOPC_Advertise(importState, "Si_ifrac", rc=localrc)
+
+  !  Melt water flux ---------------------------------------\
+  call NUOPC_Advertise(importState, "Fioi_meltw", rc=localrc)
+
+  !  Salt flux --------------------------------------------\
+  call NUOPC_Advertise(importState, "Fioi_salt", rc=localrc)
+
+  !  Heat flux ice to ocn ----------------------------------\
+  call NUOPC_Advertise(importState, "Fioi_melth", rc=localrc)
+
+  !  Pen shortwave rad through ice -------------------------\
+  call NUOPC_Advertise(importState, "Fioi_swpen", rc=localrc)
+  
+  !  freezing melting potential  --------------------------\
+  call NUOPC_Advertise(importState, "Si_frzmlt", rc=localrc)
+
+  !  freezing melting potential  -------------------------\
+  call NUOPC_Advertise(importState, "Si_CdnIO", rc=localrc)
+
+  !  ice thickness potential  -------------------------\ 
+  call NUOPC_Advertise(importState, "Si_hi", rc=localrc)
+ 
+
   ! for coupling to ATM/DATM
   call NUOPC_Advertise(importState, "air_pressure_at_sea_level", rc=localrc)
   call NUOPC_Advertise(importState, "inst_zonal_wind_height10m", rc=localrc)
@@ -447,9 +558,18 @@ subroutine InitializeAdvertise(comp, importState, exportState, clock, rc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
 
   call NUOPC_FieldAdvertise(exportState, "depth-averaged_y-velocity", "m s-1", localrc)
-  _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
+  _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc) 
 
   call NUOPC_FieldAdvertise(exportState, "sea_surface_height_above_sea_level", "m", localrc)
+  _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
+
+  call NUOPC_FieldAdvertise(exportState, "sea_surface_slope_zonal", "1", localrc)
+  _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
+
+  call NUOPC_FieldAdvertise(exportState, "sea_surface_slope_merid", "1", localrc)
+  _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
+
+  call NUOPC_FieldAdvertise(exportState, "mixed_layer_depth", "m", localrc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
 
   ! required for coupling through CMEPS mediator
@@ -470,7 +590,7 @@ subroutine InitializeRealize(comp, importState, exportState, clock, rc)
   use schism_esmf_util, only : SCHISM_MeshCreateElement
   
   !> @todo move all use statements of schism into schism_bmi
-  use schism_glbl, only: np, pr2, windx2, windy2, srad, nws, rkind
+  use schism_glbl, only: np, pr2, windx2, windy2, srad, nws, rkind, npa
   use schism_esmf_util, only: SCHISM_StateFieldCreateRealize
   implicit none
 
@@ -508,12 +628,6 @@ subroutine InitializeRealize(comp, importState, exportState, clock, rc)
   rc = ESMF_SUCCESS
   localrc= ESMF_SUCCESS
 
-!<<<<<<< HEAD
-!=======
-  !> @todo move addSchismMesh back to schism_esmf_util to share with ESMF cap
-  !> call addSchismMesh(comp, ownedNodes=ownedNodes, foreignNodes=foreignNodes, rc=localrc)
-  !call addSchismMesh(comp, localrc)
-!>>>>>>> a9a0ce0 (Use MeshCreate instead off add Mesh)
   if (meshloc == ESMF_MESHLOC_NODE) then
     call SCHISM_MeshCreateNode(comp, rc=localrc)
     _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
@@ -616,6 +730,76 @@ subroutine InitializeRealize(comp, importState, exportState, clock, rc)
   call SCHISM_StateFieldCreateRealize(comp, state=importState, &
     name="inst_prec_rate", field=field, rc=localrc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
+
+  !=============================================================
+  !             +---------------------------------+
+  !             | Adding CICE vars to import state|
+  !             +---------------------------------+
+  !=============================================================
+  
+  !> Ice_velocity ---------------------------------------------\
+  call SCHISM_StateFieldCreateRealize(comp, state=importState, &
+    name="Si_uvel", field=field, rc=localrc)
+  _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
+  call SCHISM_StateFieldCreateRealize(comp, state=importState, &
+    name="Si_vvel", field=field, rc=localrc)
+  _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
+
+  !> Ice_to_ocean_stress --------------------------------------\
+  call SCHISM_StateFieldCreateRealize(comp, state=importState, &
+    name="Fioi_taux", field=field, rc=localrc)
+  _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
+  call SCHISM_StateFieldCreateRealize(comp, state=importState, &
+    name="Fioi_tauy", field=field, rc=localrc)
+  _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
+
+  !> Volume of snow -------------------------------------------\
+  call SCHISM_StateFieldCreateRealize(comp, state=importState, &
+    name="Si_vsno", field=field, rc=localrc)
+  _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
+
+  !> Volume of ice --------------------------------------------\
+  call SCHISM_StateFieldCreateRealize(comp, state=importState, &
+    name="Si_vice", field=field, rc=localrc)
+  _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
+
+  !> ---- ice_fraction ----------------------------------------\
+  call SCHISM_StateFieldCreateRealize(comp, state=importState, &
+    name="Si_ifrac", field=field, rc=localrc)
+  _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
+ 
+  !> Melt_water_flux ------------------------------------------\
+  call SCHISM_StateFieldCreateRealize(comp, state=importState, &
+    name="Fioi_meltw", field=field, rc=localrc)
+  _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
+
+  !> Salinity_flux --------------------------------------------\
+  call SCHISM_StateFieldCreateRealize(comp, state=importState, &
+    name="Fioi_salt", field=field, rc=localrc)
+  _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
+
+  !> Heat_flux_ice_to_ocn -------------------------------------\
+  call SCHISM_StateFieldCreateRealize(comp, state=importState, &
+    name="Fioi_melth", field=field, rc=localrc)
+  _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
+
+  !> Pen_shortwave_rad_through_ice ----------------------------\
+  call SCHISM_StateFieldCreateRealize(comp, state=importState, &
+    name="Fioi_swpen", field=field, rc=localrc)
+  _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
+
+  !> freezing melting potential  ------------------------------\
+  call SCHISM_StateFieldCreateRealize(comp, state=importState, &
+    name="Si_frzmlt", field=field, rc=localrc)
+  _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
+  
+   
+  !> Ice ocean drag coeff -------------------------------------\
+  call SCHISM_StateFieldCreateRealize(comp, state=importState, &
+    name="Si_CdnIO", field=field, rc=localrc)
+  _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
+
+
 
   !> Wave parameters, for now we only have those from the WW3DATA cap in 
   !> NOAA's CoastalApp.  
@@ -966,7 +1150,7 @@ end subroutine SCHISM_RemoveUnconnectedFields
 #define ESMF_METHOD "SCHISM_Export"
 subroutine SCHISM_Export(comp, exportState, clock, rc)
 
-  use schism_glbl,      only: nvrt, eta2, dav, uu2, vv2, tr_nd, idry_e, npa
+  use schism_glbl,      only: nvrt, eta2, dav, uu2, vv2, tr_nd, idry_e, deta1_dxy_elem, dp, znl, nvrt, npa
   use schism_esmf_util, only: SCHISM_StateUpdate
 
   implicit none
@@ -984,6 +1168,7 @@ subroutine SCHISM_Export(comp, exportState, clock, rc)
   integer(ESMF_KIND_I4) :: localrc
   real(ESMF_KIND_R8), allocatable, save, target :: idry_r8(:)
   real(ESMF_KIND_R8), allocatable, save, target :: sst_K(:)
+  real(ESMF_KIND_R8), allocatable, save, target :: hmix(:)
   character(len=ESMF_MAXSTR) :: timeStr
   character(len=*), parameter :: subname = '(SCHISM_Export): '
   !--------------------------------
@@ -1005,7 +1190,15 @@ subroutine SCHISM_Export(comp, exportState, clock, rc)
   call SCHISM_StateUpdate(exportState, 'sea_surface_height_above_sea_level', eta2, &
     isPtr=isDataPtr, rc=localrc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
-
+ 
+  !> Sea surface graidend (for cice coupling) 
+  call SCHISM_StateUpdate(exportState, 'sea_surface_slope_zonal', deta1_dxy_elem(:,1), &
+    isPtr=isDataPtr, rc=localrc)
+  _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
+  call SCHISM_StateUpdate(exportState, 'sea_surface_slope_merid', deta1_dxy_elem(:,2), &
+    isPtr=isDataPtr, rc=localrc)
+  _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
+  
   !> depth average current in x direction
   call SCHISM_StateUpdate(exportState, 'depth-averaged_x-velocity', dav(1,:), &
     isPtr=isDataPtr, rc=localrc)
@@ -1023,6 +1216,17 @@ subroutine SCHISM_Export(comp, exportState, clock, rc)
 
   !> surface current in y direction
   call SCHISM_StateUpdate(exportState, 'ocn_current_merid', vv2(nvrt,:), &
+    isPtr=isDataPtr, rc=localrc)
+  _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
+
+
+  !> mixedlayer depth (CICE coupling) 
+  if (.not. allocated(hmix)) then
+     allocate(hmix(npa))
+     hmix(:) = min( abs(znl(nvrt,:) - znl(nvrt-1,:)) , max( 0.d0, dp(:) + eta2(:) ))
+  end if
+
+  call SCHISM_StateUpdate(exportState, 'mixed_layer_depth', hmix(:), &
     isPtr=isDataPtr, rc=localrc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
 
@@ -1074,7 +1278,12 @@ end subroutine SCHISM_Export
 subroutine SCHISM_Import(comp, importState, clock, rc)
 
   use schism_glbl     , only: RADFLAG, windx2, windy2, pr2
-  use schism_glbl     , only: airt2,shum2,srad,hradd,fluxprc
+  use schism_glbl     , only: airt2,shum2,srad,hradd,fluxprc,npa
+  use schism_glbl     , only: uvice,vvice,taux,tauy,vsno,vice, &
+                              aice,ifresh_flux,isalt_flux,iheat_flux, &
+                              isw_pen,frzmlt,tau_oi,fresh_wa_flux, &
+                              salinity_flux,net_heat_flux,srad_th_ice,CdnIO,znl, nvrt
+
   use schism_esmf_util, only: SCHISM_StateImportWaveTensor
   use schism_esmf_util, only: SCHISM_StateImportWave3dVortex
   use schism_esmf_util, only: SCHISM_StateUpdate
@@ -1086,9 +1295,28 @@ subroutine SCHISM_Import(comp, importState, clock, rc)
   type(ESMF_State)   , intent(inout) :: importState
   type(ESMF_Clock)   , intent(in)    :: clock
   integer            , intent(inout) :: rc
+  !>---------------------------------------------------
+  !         Creating vars to dump cice fields to
+  !>---------------------------------------------------
+  !real(ESMF_KIND_R8), allocatable, save, target :: uvice(:)
+  !real(ESMF_KIND_R8), allocatable, save, target :: vvice(:)
+  !real(ESMF_KIND_R8), allocatable, save, target :: taux(:)
+  !real(ESMF_KIND_R8), allocatable, save, target :: tauy(:)
+  !real(ESMF_KIND_R8), allocatable, save, target :: vsno(:)
+  !real(ESMF_KIND_R8), allocatable, save, target :: vice(:)
+  !real(ESMF_KIND_R8), allocatable, save, target :: aice(:)
+  !real(ESMF_KIND_R8), allocatable, save, target :: ifresh_flux(:)
+  !real(ESMF_KIND_R8), allocatable, save, target :: isalt_flux(:)
+  !real(ESMF_KIND_R8), allocatable, save, target :: iheat_flux(:)  
+  !real(ESMF_KIND_R8), allocatable, save, target :: isw_pen(:)
+  !real(ESMF_KIND_R8), allocatable, save, target :: frzmlt(:)
 
+  !>---------------------------------------------------
+  !>---------------------------------------------------
+  
   !> Local variables
   type(ESMF_Time) :: currTime
+  integer         :: i
   type(type_InternalStateWrapper) :: internalState
   type(type_InternalState), pointer :: isDataPtr => null()
   integer(ESMF_KIND_I4) :: localrc
@@ -1158,6 +1386,189 @@ subroutine SCHISM_Import(comp, importState, clock, rc)
   call SCHISM_StateUpdate(importState, 'inst_prec_rate', fluxprc, &
     isPtr=isDataPtr, rc=localrc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
+    
+  !>-------------------------------------------------------
+  !>              Allocated vars to dump import to
+  !>-------------------------------------------------------
+  
+  if (.not. allocated(uvice)) then
+      allocate(uvice(npa))
+      uvice(:) =0.0d0
+  end if
+  if (.not. allocated(vvice)) then
+      allocate(vvice(npa))
+      vvice(:) =0.0d0
+  end if
+  if (.not. allocated(taux)) then
+      allocate(taux(npa))
+      taux(:) =0.0d0
+  end if
+  if (.not. allocated(tauy)) then
+      allocate(tauy(npa))
+      tauy(:) =0.0d0
+  end if
+  if (.not. allocated(vsno)) then
+      allocate(vsno(npa))
+      vsno(:) =0.0d0
+  end if
+  if (.not. allocated(vice)) then
+      allocate(vice(npa))
+      vice(:) =0.0d0
+  end if
+  if (.not. allocated(aice)) then
+      allocate(aice(npa))
+      aice(:) =0.0d0
+  end if
+  if (.not. allocated(ifresh_flux)) then
+      allocate(ifresh_flux(npa))
+      ifresh_flux(:) =0.0d0
+  end if
+  if (.not. allocated(isalt_flux)) then
+      allocate(isalt_flux(npa))
+      isalt_flux(:) =0.0d0
+  end if
+  if (.not. allocated(iheat_flux)) then
+      allocate(iheat_flux(npa))
+      iheat_flux(:) =0.0d0
+  end if
+  if (.not. allocated(isw_pen)) then
+      allocate(isw_pen(npa))
+      isw_pen(:) =0.0d0
+  end if
+  if (.not. allocated(frzmlt)) then
+      allocate(frzmlt(npa))
+      frzmlt(:) =0.0d0
+  end if
+  if (.not. allocated(CdnIO)) then
+      allocate(CdnIO(npa))
+      CdnIO(:) =0.0d0
+  end if
+  
+
+  !====================================================================
+  !                 +--------------------------------+
+  !                 | Importing CICE vars into schism|
+  !                 +--------------------------------+
+  !=====================================================================
+  !> Zonal-direction ------------------------------------\
+  call SCHISM_StateUpdate(importState, 'Si_uvel', uvice, &
+    isPtr=isDataPtr, rc=localrc)
+  _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
+  !> Merid-direction ------------------------------------\
+  call SCHISM_StateUpdate(importState, 'Si_vvel', vvice, &
+    isPtr=isDataPtr, rc=localrc)
+  _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
+  !> ice-stress Zonal-direction --------------------------\
+  call SCHISM_StateUpdate(importState, 'Fioi_taux', taux, &
+    isPtr=isDataPtr, rc=localrc)
+  _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
+  !> ice-stress Merid-direction --------------------------\
+  call SCHISM_StateUpdate(importState, 'Fioi_tauy', tauy, &
+    isPtr=isDataPtr, rc=localrc)
+  _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
+  !> Volume of snow ------------------------------------\
+  call SCHISM_StateUpdate(importState, 'Si_vsno', vsno, &
+    isPtr=isDataPtr, rc=localrc)
+  _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
+
+  !> Volume of ice -------------------------------------\
+  call SCHISM_StateUpdate(importState, 'Si_vice', vice, &
+    isPtr=isDataPtr, rc=localrc)
+  _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
+
+  !> ice_fraction ---------------------------------------\
+  call SCHISM_StateUpdate(importState, 'Si_ifrac', aice, &
+    isPtr=isDataPtr, rc=localrc)
+  _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
+
+  !> Melt_water_flux --------------------------------------------\
+  call SCHISM_StateUpdate(importState, 'Fioi_meltw', ifresh_flux, &
+    isPtr=isDataPtr, rc=localrc)
+  _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
+
+  !> Melt_water_flux -------------------------------------------\
+  call SCHISM_StateUpdate(importState, 'Fioi_salt', isalt_flux, &
+    isPtr=isDataPtr, rc=localrc)
+  _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
+
+  !> Heat_flux_ice_to_ocn ---------------------------------------\
+  call SCHISM_StateUpdate(importState, 'Fioi_melth', iheat_flux, &
+    isPtr=isDataPtr, rc=localrc)
+  _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
+ 
+  !> Heat_flux_ice_to_ocn ------------------------------------\
+  call SCHISM_StateUpdate(importState, 'Fioi_swpen', isw_pen, &
+    isPtr=isDataPtr, rc=localrc)
+  _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
+ 
+  !> freezing melting potential  ---------------------------\
+  call SCHISM_StateUpdate(importState, 'Si_frzmlt', frzmlt, &
+    isPtr=isDataPtr, rc=localrc)
+  _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
+
+    
+  ! Ice-to-ocean drag coeff  ------------------------------\
+  call SCHISM_StateUpdate(importState, 'Si_CdnIO', CdnIO, &
+    isPtr=isDataPtr, rc=localrc)
+  _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
+
+
+
+  !               +---------------------+
+  !               | CICE Export to hydro|
+  !               +---------------------+
+  i=0
+  do i = 1,npa
+    if (aice(i) > real(0.0)) then
+      !>Ice ocean stress -------------------------------\
+      !>Taux,Tauy are in units of [N/m/m]
+      !>Weighted by ice area on T-grid (CICE)
+
+      tau_oi(1,i)=taux(i)
+      tau_oi(2,i)=tauy(i)
+
+
+      !> Salinity flux ---------------------------------\
+      !> This is the slainity flux to the ocean form ice 
+      !> formaiton and melt. isalt has units [kg/s/m/m] 
+      !> to convert to [psu/s] divide by volume of fresh 
+      !> water in the top layer of the grid per unit area. 
+      !> In kg
+      
+      salinity_flux(i) = aice(i)*(isalt_flux(i))/real(1000)
+
+      !>Fresh water flux -------------------------------\
+      !> ifresh_flux is in units of [kg/s/m/m]
+      !> Water is distributed across whole element
+      !> denisty of fresh 1000 [kg/m/m/m]
+
+
+      fresh_wa_flux(i) = ifresh_flux(i)!*rho0
+
+      !>Heat flux ice to ocean  ------------------------\
+      !> iheat_flux is in units of [W/m/m]
+      !> Energy is distributed across whole element
+
+      net_heat_flux(i) = iheat_flux(i) !+ max(real(0.0),frzmlt(i))
+
+      !>Short-wave pen. flux ---------------------------\
+      !>isw_pen is in units of [W/m/m]
+      !>Weighted by ice area
+      srad_th_ice(i)  = isw_pen(i)
+
+    else
+      !> No ice so all these values are zero
+      tau_oi(1,i)      = real(0)
+      tau_oi(2,i)      = real(0)
+      salinity_flux(i) = real(0)
+      fresh_wa_flux(i) = real(0) !+ max(real(0.0),frzmlt(i))
+      net_heat_flux(i) = real(0)
+      srad_th_ice(i)  = real(0)
+    endif
+
+  enddo
+
+
 
   !> Write fields on import state for debugging
   if (debug_level > 0) then

--- a/src/schism/schism_nuopc_cap.F90
+++ b/src/schism/schism_nuopc_cap.F90
@@ -391,94 +391,94 @@ subroutine InitializeAdvertise(comp, importState, exportState, clock, rc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
 
   !  Adding CICE fields to ufs_fd
-  !  Zonal ice velocity [m/s] --------------------------------------\
+  !  Zonal ice velocity [m/s] --------------------------------------
   call NUOPC_FieldDictionaryAddIfNeeded("Si_uvel", "m s-1", localrc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
 
-  !  Merid ice velocity [m/s] --------------------------------------\
+  !  Merid ice velocity [m/s] --------------------------------------
   call NUOPC_FieldDictionaryAddIfNeeded("Si_vvel", "m s-1", localrc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
 
-  !  Zonal ice-to-ocean stress [N/m/m] -------------------------------\
+  !  Zonal ice-to-ocean stress [N/m/m] -------------------------------
   call NUOPC_FieldDictionaryAddIfNeeded("Fioi_taux", "N m-2", localrc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
 
-  !  Merid ice-to-ocean stress [N/m/m] -------------------------------\
+  !  Merid ice-to-ocean stress [N/m/m] -------------------------------
   call NUOPC_FieldDictionaryAddIfNeeded("Fioi_tauy", "N m-2", localrc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
 
-  !  Snow volume (per unit area) [m] ----------------------------\
+  !  Snow volume (per unit area) [m] ----------------------------
   call NUOPC_FieldDictionaryAddIfNeeded("Si_vsno", "m", localrc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
 
-  !  Ice volume (per unit area) [m] ---------- ------------------\
+  !  Ice volume (per unit area) [m] ---------- ------------------
   call NUOPC_FieldDictionaryAddIfNeeded("Si_vice", "m", localrc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
 
-  !  Fresh water flux due to ice melting [kg/m/m/s] ------------------------\
+  !  Fresh water flux due to ice melting [kg/m/m/s] ------------------------
   call NUOPC_FieldDictionaryAddIfNeeded("Fioi_meltw", "kg m-2 s-1", localrc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
  
-  !  Salt flux due to ice formation/melt [kg/m/m/s] -----------------------\
+  !  Salt flux due to ice formation/melt [kg/m/m/s] -----------------------
   call NUOPC_FieldDictionaryAddIfNeeded("Fioi_salt", "kg m-2 s-1", localrc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
 
-  !  Heat flux at the base of the ice [W/m/m] --------------------------\
+  !  Heat flux at the base of the ice [W/m/m] --------------------------
   call NUOPC_FieldDictionaryAddIfNeeded("Fioi_melth", "W m-2", localrc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
 
-  !  Shortwave radiation through sea ice coverage [W/m/m] --------------\
+  !  Shortwave radiation through sea ice coverage [W/m/m] --------------
   call NUOPC_FieldDictionaryAddIfNeeded("Fioi_swpen", "W m-2", localrc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
   
-  !  Freezing melting potential (energy for ice formation) [W/m/m] ---\
+  !  Freezing melting potential (energy for ice formation) [W/m/m] ---
   call NUOPC_FieldDictionaryAddIfNeeded("Si_frzmlt", "W m-2", localrc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
 
-  !  Ice-to-ocean drage coef [Unitless] -------------------------\
+  !  Ice-to-ocean drage coef [Unitless] -------------------------
   call NUOPC_FieldDictionaryAddIfNeeded("Si_CdnIO", "1", localrc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
 
   ! Advertizing CICE states
-  ! Sea surface height--------------------------------------------------------------\ 
+  ! Sea surface height-------------------------------------------------------------- 
   call NUOPC_Advertise(importState, "sea_surface_height_above_sea_level", rc=localrc)
   
-  !  Zonal/Merid ice velocity -----------------------------\
+  !  Zonal/Merid ice velocity -----------------------------
   call NUOPC_Advertise(importState, "Si_uvel", rc=localrc)
   call NUOPC_Advertise(importState, "Si_vvel", rc=localrc)
 
-  !  Zonal/Merid ice-to-ocn stress ------------------------\
+  !  Zonal/Merid ice-to-ocn stress ------------------------
   call NUOPC_Advertise(importState, "Fioi_taux", rc=localrc)
   call NUOPC_Advertise(importState, "Fioi_tauy", rc=localrc)
  
-  !  Snow volume ----------------------------------------\
+  !  Snow volume ----------------------------------------
   call NUOPC_Advertise(importState, "Si_vsno", rc=localrc)
 
-  !  Ice volume -----------------------------------------\
+  !  Ice volume -----------------------------------------
   call NUOPC_Advertise(importState, "Si_vice", rc=localrc)
 
-  !  Ice fraction ----------------------------------------\
+  !  Ice fraction ----------------------------------------
   call NUOPC_Advertise(importState, "Si_ifrac", rc=localrc)
 
-  !  Melt water flux ---------------------------------------\
+  !  Melt water flux ---------------------------------------
   call NUOPC_Advertise(importState, "Fioi_meltw", rc=localrc)
 
-  !  Salt flux --------------------------------------------\
+  !  Salt flux --------------------------------------------
   call NUOPC_Advertise(importState, "Fioi_salt", rc=localrc)
 
-  !  Heat flux ice to ocn ----------------------------------\
+  !  Heat flux ice to ocn ----------------------------------
   call NUOPC_Advertise(importState, "Fioi_melth", rc=localrc)
 
-  !  Pen shortwave rad through ice -------------------------\
+  !  Pen shortwave rad through ice -------------------------
   call NUOPC_Advertise(importState, "Fioi_swpen", rc=localrc)
   
-  !  freezing melting potential  --------------------------\
+  !  freezing melting potential  --------------------------
   call NUOPC_Advertise(importState, "Si_frzmlt", rc=localrc)
 
-  !  freezing melting potential  -------------------------\
+  !  freezing melting potential  -------------------------
   call NUOPC_Advertise(importState, "Si_CdnIO", rc=localrc)
 
-  !  ice thickness potential  -------------------------\ 
+  !  ice thickness potential  ------------------------- 
   call NUOPC_Advertise(importState, "Si_hi", rc=localrc)
   
   ! for coupling to ATM/DATM
@@ -718,7 +718,7 @@ subroutine InitializeRealize(comp, importState, exportState, clock, rc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
 
   !  Adding CICE vars to import state 
-  !> Ice_velocity ---------------------------------------------\
+  !> Ice_velocity ---------------------------------------------
   call SCHISM_StateFieldCreateRealize(comp, state=importState, &
     name="Si_uvel", field=field, rc=localrc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
@@ -726,7 +726,7 @@ subroutine InitializeRealize(comp, importState, exportState, clock, rc)
     name="Si_vvel", field=field, rc=localrc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
 
-  !> Ice_to_ocean_stress --------------------------------------\
+  !> Ice_to_ocean_stress --------------------------------------
   call SCHISM_StateFieldCreateRealize(comp, state=importState, &
     name="Fioi_taux", field=field, rc=localrc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
@@ -734,48 +734,48 @@ subroutine InitializeRealize(comp, importState, exportState, clock, rc)
     name="Fioi_tauy", field=field, rc=localrc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
 
-  !> Volume of snow -------------------------------------------\
+  !> Volume of snow -------------------------------------------
   call SCHISM_StateFieldCreateRealize(comp, state=importState, &
     name="Si_vsno", field=field, rc=localrc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
 
-  !> Volume of ice --------------------------------------------\
+  !> Volume of ice --------------------------------------------
   call SCHISM_StateFieldCreateRealize(comp, state=importState, &
     name="Si_vice", field=field, rc=localrc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
 
-  !> ---- ice_fraction ----------------------------------------\
+  !> ---- ice_fraction ----------------------------------------
   call SCHISM_StateFieldCreateRealize(comp, state=importState, &
     name="Si_ifrac", field=field, rc=localrc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
  
-  !> Melt_water_flux ------------------------------------------\
+  !> Melt_water_flux ------------------------------------------
   call SCHISM_StateFieldCreateRealize(comp, state=importState, &
     name="Fioi_meltw", field=field, rc=localrc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
 
-  !> Salinity_flux --------------------------------------------\
+  !> Salinity_flux --------------------------------------------
   call SCHISM_StateFieldCreateRealize(comp, state=importState, &
     name="Fioi_salt", field=field, rc=localrc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
 
-  !> Heat_flux_ice_to_ocn -------------------------------------\
+  !> Heat_flux_ice_to_ocn -------------------------------------
   call SCHISM_StateFieldCreateRealize(comp, state=importState, &
     name="Fioi_melth", field=field, rc=localrc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
 
-  !> Pen_shortwave_rad_through_ice ----------------------------\
+  !> Pen_shortwave_rad_through_ice ----------------------------
   call SCHISM_StateFieldCreateRealize(comp, state=importState, &
     name="Fioi_swpen", field=field, rc=localrc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
 
-  !> freezing melting potential  ------------------------------\
+  !> freezing melting potential  ------------------------------
   call SCHISM_StateFieldCreateRealize(comp, state=importState, &
     name="Si_frzmlt", field=field, rc=localrc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
   
    
-  !> Ice ocean drag coeff -------------------------------------\
+  !> Ice ocean drag coeff -------------------------------------
   call SCHISM_StateFieldCreateRealize(comp, state=importState, &
     name="Si_CdnIO", field=field, rc=localrc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
@@ -1406,66 +1406,64 @@ subroutine SCHISM_Import(comp, importState, clock, rc)
       CdnIO(:) =0.0d0
   end if
   
-
   !  Importing CICE vars into schism
-  !> Zonal-direction ------------------------------------\
+  !> Zonal-direction ------------------------------------
   call SCHISM_StateUpdate(importState, 'Si_uvel', uvice, &
     isPtr=isDataPtr, rc=localrc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
-  !> Merid-direction ------------------------------------\
+  !> Merid-direction ------------------------------------
   call SCHISM_StateUpdate(importState, 'Si_vvel', vvice, &
     isPtr=isDataPtr, rc=localrc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
-  !> ice-stress Zonal-direction --------------------------\
+  !> ice-stress Zonal-direction -------------------------
   call SCHISM_StateUpdate(importState, 'Fioi_taux', taux, &
     isPtr=isDataPtr, rc=localrc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
-  !> ice-stress Merid-direction --------------------------\
+  !> ice-stress Merid-direction -------------------------
   call SCHISM_StateUpdate(importState, 'Fioi_tauy', tauy, &
     isPtr=isDataPtr, rc=localrc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
-  !> Volume of snow ------------------------------------\
+  !> Volume of snow ------------------------------------
   call SCHISM_StateUpdate(importState, 'Si_vsno', vsno, &
     isPtr=isDataPtr, rc=localrc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
 
-  !> Volume of ice -------------------------------------\
+  !> Volume of ice -------------------------------------
   call SCHISM_StateUpdate(importState, 'Si_vice', vice, &
     isPtr=isDataPtr, rc=localrc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
 
-  !> ice_fraction ---------------------------------------\
+  !> ice_fraction ---------------------------------------
   call SCHISM_StateUpdate(importState, 'Si_ifrac', aice, &
     isPtr=isDataPtr, rc=localrc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
 
-  !> Melt_water_flux --------------------------------------------\
+  !> Melt_water_flux --------------------------------------------
   call SCHISM_StateUpdate(importState, 'Fioi_meltw', ifresh_flux, &
     isPtr=isDataPtr, rc=localrc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
 
-  !> Melt_water_flux -------------------------------------------\
+  !> Melt_water_flux -------------------------------------------
   call SCHISM_StateUpdate(importState, 'Fioi_salt', isalt_flux, &
     isPtr=isDataPtr, rc=localrc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
 
-  !> Heat_flux_ice_to_ocn ---------------------------------------\
+  !> Heat_flux_ice_to_ocn ---------------------------------------
   call SCHISM_StateUpdate(importState, 'Fioi_melth', iheat_flux, &
     isPtr=isDataPtr, rc=localrc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
  
-  !> Heat_flux_ice_to_ocn ------------------------------------\
+  !> Heat_flux_ice_to_ocn ------------------------------------
   call SCHISM_StateUpdate(importState, 'Fioi_swpen', isw_pen, &
     isPtr=isDataPtr, rc=localrc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
  
-  !> freezing melting potential  ---------------------------\
+  !> freezing melting potential  ---------------------------
   call SCHISM_StateUpdate(importState, 'Si_frzmlt', frzmlt, &
     isPtr=isDataPtr, rc=localrc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
 
-    
-  ! Ice-to-ocean drag coeff  ------------------------------\
+  ! Ice-to-ocean drag coeff  ------------------------------
   call SCHISM_StateUpdate(importState, 'Si_CdnIO', CdnIO, &
     isPtr=isDataPtr, rc=localrc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
@@ -1475,32 +1473,32 @@ subroutine SCHISM_Import(comp, importState, clock, rc)
   i=0
   do i = 1,npa
     if (aice(i) > real(0.0)) then
-      !>Ice ocean stress -------------------------------\
+      !>Ice ocean stress -------------------------------
       !>Taux,Tauy are in units of [N/m/m]
 
       tau_oi(1,i)=taux(i)
       tau_oi(2,i)=tauy(i)
 
 
-      !> Salinity flux ---------------------------------\
+      !> Salinity flux ---------------------------------
       !> This is the slainity flux to the ocean from ice 
       !> formaiton and melt. isalt has units [kg/s/m/m] 
       
       salinity_flux(i) = aice(i)*(isalt_flux(i))/real(1000)
 
-      !>Fresh water flux -------------------------------\
+      !>Fresh water flux -------------------------------
       !> ifresh_flux is in units of [kg/s/m/m]
       !> Water is distributed across whole element
 
-      fresh_wa_flux(i) = ifresh_flux(i)!*rho0
+      fresh_wa_flux(i) = ifresh_flux(i)
 
-      !>Heat flux ice to ocean  ------------------------\
+      !>Heat flux ice to ocean  ------------------------
       !> iheat_flux is in units of [W/m/m]
       !> Energy is distributed across whole element
 
-      net_heat_flux(i) = iheat_flux(i) !+ max(real(0.0),frzmlt(i))
+      net_heat_flux(i) = iheat_flux(i)
 
-      !>Short-wave pen. flux ---------------------------\
+      !>Short-wave pen. flux ---------------------------
       !>isw_pen is in units of [W/m/m]
       !>Weighted by ice area
       srad_th_ice(i)  = isw_pen(i)

--- a/src/schism/schism_nuopc_cap.F90
+++ b/src/schism/schism_nuopc_cap.F90
@@ -435,12 +435,6 @@ subroutine InitializeAdvertise(comp, importState, exportState, clock, rc)
   call NUOPC_Advertise(importState, "Si_hi", rc=localrc)
 #endif USE_CICE
 
-  !  freezing melting potential  -------------------------
-  call NUOPC_Advertise(importState, "Si_CdnIO", rc=localrc)
-
-  !  ice thickness potential  ------------------------- 
-  call NUOPC_Advertise(importState, "Si_hi", rc=localrc)
-  
   ! for coupling to ATM/DATM
   call NUOPC_Advertise(importState, "air_pressure_at_sea_level", rc=localrc)
   call NUOPC_Advertise(importState, "inst_zonal_wind_height10m", rc=localrc)
@@ -1486,8 +1480,7 @@ subroutine SCHISM_Import(comp, importState, clock, rc)
       !>Taux,Tauy are in units of [N/m/m]
 
       tau_oi(1,i)=taux_ice(i)
-      tau_oi(1,i)=tauy_ice(i)
-
+      tau_oi(2,i)=tauy_ice(i)
 
       !> Salinity flux ---------------------------------
       !> This is the slainity flux to the ocean from ice 

--- a/src/schism/schism_nuopc_cap.F90
+++ b/src/schism/schism_nuopc_cap.F90
@@ -1477,26 +1477,20 @@ subroutine SCHISM_Import(comp, importState, clock, rc)
     if (aice(i) > real(0.0)) then
       !>Ice ocean stress -------------------------------\
       !>Taux,Tauy are in units of [N/m/m]
-      !>Weighted by ice area on T-grid (CICE)
 
       tau_oi(1,i)=taux(i)
       tau_oi(2,i)=tauy(i)
 
 
       !> Salinity flux ---------------------------------\
-      !> This is the slainity flux to the ocean form ice 
+      !> This is the slainity flux to the ocean from ice 
       !> formaiton and melt. isalt has units [kg/s/m/m] 
-      !> to convert to [psu/s] divide by volume of fresh 
-      !> water in the top layer of the grid per unit area. 
-      !> In kg
       
       salinity_flux(i) = aice(i)*(isalt_flux(i))/real(1000)
 
       !>Fresh water flux -------------------------------\
       !> ifresh_flux is in units of [kg/s/m/m]
       !> Water is distributed across whole element
-      !> denisty of fresh 1000 [kg/m/m/m]
-
 
       fresh_wa_flux(i) = ifresh_flux(i)!*rho0
 

--- a/src/schism/schism_nuopc_cap.F90
+++ b/src/schism/schism_nuopc_cap.F90
@@ -614,13 +614,12 @@ subroutine InitializeRealize(comp, importState, exportState, clock, rc)
   rc = ESMF_SUCCESS
   localrc= ESMF_SUCCESS
 
-  if (meshloc == ESMF_MESHLOC_NODE) then
-    call SCHISM_MeshCreateNode(comp, rc=localrc)
-    _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
-  else
-    call SCHISM_MeshCreateElement(comp, rc=localrc)
-    _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
-  end if
+  ! Create mesh on both node and element
+  call SCHISM_MeshCreateNode(comp, rc=localrc)
+  _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
+
+  call SCHISM_MeshCreateElement(comp, rc=localrc)
+  _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
 
   call ESMF_GridCompGet(comp, mesh=mesh2d, name=compName, rc=localrc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
@@ -1133,6 +1132,7 @@ subroutine SCHISM_Export(comp, exportState, clock, rc)
 
   use schism_glbl,      only: nvrt, eta2, dav, uu2, vv2, tr_nd, idry_e, npa, deta1_dxy_elem, dp, znl, nvrt
   use schism_esmf_util, only: SCHISM_StateUpdate
+  use schism_esmf_util, only: fieldNode, fieldElem, routeHandleN2E
 
   implicit none
 
@@ -1151,6 +1151,8 @@ subroutine SCHISM_Export(comp, exportState, clock, rc)
   real(ESMF_KIND_R8), allocatable, save, target :: sst_K(:)
   real(ESMF_KIND_R8), allocatable, save, target :: hmix(:)
   character(len=ESMF_MAXSTR) :: timeStr
+  integer :: itemCount, srcTermProcessing_Value = 0
+  logical, save :: firstTime = .true.
   character(len=*), parameter :: subname = '(SCHISM_Export): '
   !--------------------------------
 
@@ -1166,13 +1168,32 @@ subroutine SCHISM_Export(comp, exportState, clock, rc)
   if(.not.associated(isDataPtr)) localrc = ESMF_RC_PTR_NULL
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
 
+  !> Check if we need transfer fields from node to element. If so, create routehandle
+  if (meshloc == ESMF_MESHLOC_ELEMENT) then
+     !> Check this is initial call or not
+     if (firstTime) then
+        !> Create routehandle node -> element
+        call ESMF_FieldRegridStore(fieldNode, fieldElem, &
+               routehandle=routeHandleN2E, &
+               regridmethod=ESMF_REGRIDMETHOD_BILINEAR, &
+               srcTermProcessing=srcTermProcessing_Value, &
+               ignoreDegenerate=.true., &
+               unmappedaction=ESMF_UNMAPPEDACTION_IGNORE, &
+               rc=localrc)
+        _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
+
+        !> Set flag
+        firstTime = .false.
+     end if
+  end if
+
   !> Update fields on export state
   !> sea surface height
   call SCHISM_StateUpdate(exportState, 'sea_surface_height_above_sea_level', eta2, &
     isPtr=isDataPtr, rc=localrc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
 
-  !> Sea surface graidend (for cice coupling) 
+  !> Sea surface graidend (for cice coupling)
   call SCHISM_StateUpdate(exportState, 'sea_surface_slope_zonal', deta1_dxy_elem(:,1), &
     isPtr=isDataPtr, rc=localrc)
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
@@ -1267,6 +1288,7 @@ subroutine SCHISM_Import(comp, importState, clock, rc)
   use schism_esmf_util, only: SCHISM_StateImportWaveTensor
   use schism_esmf_util, only: SCHISM_StateImportWave3dVortex
   use schism_esmf_util, only: SCHISM_StateUpdate
+  use schism_esmf_util, only: fieldNode, fieldElem, routeHandleE2N
 
   implicit none
 
@@ -1282,6 +1304,8 @@ subroutine SCHISM_Import(comp, importState, clock, rc)
   type(type_InternalStateWrapper) :: internalState
   type(type_InternalState), pointer :: isDataPtr => null()
   integer(ESMF_KIND_I4) :: localrc
+  integer :: itemCount, srcTermProcessing_Value = 0
+  logical :: firstTime = .true.
   character(len=ESMF_MAXSTR) :: timeStr
   character(len=*), parameter :: subname = '(SCHISM_Import): '
   !--------------------------------
@@ -1297,6 +1321,28 @@ subroutine SCHISM_Import(comp, importState, clock, rc)
 
   if(.not.associated(isDataPtr)) localrc = ESMF_RC_PTR_NULL
   _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
+
+  !> Check if we need transfer fields from element to node. If so, create routehandle
+  if (meshloc == ESMF_MESHLOC_ELEMENT) then
+     !> Check this is initial call or not
+     if (firstTime) then
+        !> Create routehandle element -> node
+        call ESMF_FieldRegridStore(fieldElem, fieldNode, &
+               routehandle=routeHandleE2N, &
+               regridmethod=ESMF_REGRIDMETHOD_BILINEAR, &
+               extrapMethod=ESMF_EXTRAPMETHOD_NEAREST_IDAVG, &
+               extrapNumLevels=3, &
+               extrapNumSrcPnts=16, &
+               srcTermProcessing=srcTermProcessing_Value, &
+               ignoreDegenerate=.true., &
+               unmappedaction=ESMF_UNMAPPEDACTION_IGNORE, &
+               rc=localrc)
+        _SCHISM_LOG_AND_FINALIZE_ON_ERROR_(rc)
+
+        !> Set flag
+        firstTime = .false.
+     end if
+  end if
 
   !> Update fields on import state
   if (RADFLAG == 'VOR') then


### PR DESCRIPTION
This PR aims to bring following changes:

- Changes related with CICE6 coupling that are implemented by @SmithJos13 
- Changes related with node -> element and element -> node conversion using ESMF interpolation routines. This is currently using bilinear type interpolation (along with extrapolation support) but we could bring other interpolation types in the future.

This is tested under UFS Coastal with variety configurations.

Note: We will have another PR in model side related with CICE coupling. So, it would be nice to merge both in a synchronized way. So, we could update UFS Coastal forks and point to main branch for both model and NUOPC "cap".